### PR TITLE
Fix double click on mobile issue

### DIFF
--- a/script/sketch.js
+++ b/script/sketch.js
@@ -29,6 +29,8 @@ function mousePressed() {
 
   chapters[currentChapterIndex].mousePressed();
   chapters[currentChapterIndex].playAudio();
+
+  return false;
 }
 
 
@@ -37,9 +39,11 @@ function mousePressed() {
  * touch events, like swiping left for "back" or scrolling
  * the page.
  */
-// function touchStarted(){
-//   return false;
-// }
+
+
+function touchStarted(e){
+//   // return false;
+}
 
 // function touchMoved(){
 //   return false;


### PR DESCRIPTION
This appears to be due to an event bubbling issue in Safari but if you declare touchStarted as an empty function and return false in mousePressed you can get rid of the double click events